### PR TITLE
Add Ternary, Range and Optional matches

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -73,7 +73,7 @@ func (c *Client) Run(
 	}()
 
 	stream.Send(&p4_v1.StreamMessageRequest{
-		Update: &p4_v1.StreamMessageRequest_Arbitration{&p4_v1.MasterArbitrationUpdate{
+		Update: &p4_v1.StreamMessageRequest_Arbitration{Arbitration: &p4_v1.MasterArbitrationUpdate{
 			DeviceId:   c.deviceID,
 			ElectionId: &c.electionID,
 		}},

--- a/pkg/client/counters.go
+++ b/pkg/client/counters.go
@@ -17,7 +17,7 @@ func (c *Client) ModifyCounterEntry(counter string, index int64, data *p4_v1.Cou
 	update := &p4_v1.Update{
 		Type: p4_v1.Update_MODIFY,
 		Entity: &p4_v1.Entity{
-			Entity: &p4_v1.Entity_CounterEntry{entry},
+			Entity: &p4_v1.Entity_CounterEntry{CounterEntry: entry},
 		},
 	}
 	return c.WriteUpdate(update)
@@ -30,7 +30,7 @@ func (c *Client) ReadCounterEntry(counter string, index int64) (*p4_v1.CounterDa
 		Index:     &p4_v1.Index{Index: index},
 	}
 	readEntity, err := c.ReadEntitySingle(&p4_v1.Entity{
-		Entity: &p4_v1.Entity_CounterEntry{entry},
+		Entity: &p4_v1.Entity_CounterEntry{CounterEntry: entry},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error when reading counter entry: %v", err)
@@ -63,7 +63,7 @@ func (c *Client) ReadCounterEntryWildcard(counter string) ([]*p4_v1.CounterData,
 		}
 	}()
 	if err := c.ReadEntityWildcard(&p4_v1.Entity{
-		Entity: &p4_v1.Entity_CounterEntry{entry},
+		Entity: &p4_v1.Entity_CounterEntry{CounterEntry: entry},
 	}, readEntityCh); err != nil {
 		return nil, fmt.Errorf("error when reading counter entries: %v", err)
 	}

--- a/pkg/client/digests.go
+++ b/pkg/client/digests.go
@@ -6,7 +6,7 @@ import (
 
 func (c *Client) AckDigestList(digestList *p4_v1.DigestList) error {
 	m := &p4_v1.StreamMessageRequest{
-		Update: &p4_v1.StreamMessageRequest_DigestAck{&p4_v1.DigestListAck{
+		Update: &p4_v1.StreamMessageRequest_DigestAck{DigestAck: &p4_v1.DigestListAck{
 			DigestId: digestList.DigestId,
 			ListId:   digestList.ListId,
 		}},
@@ -24,7 +24,7 @@ func (c *Client) EnableDigest(digest string, config *p4_v1.DigestEntry_Config) e
 	update := &p4_v1.Update{
 		Type: p4_v1.Update_INSERT,
 		Entity: &p4_v1.Entity{
-			Entity: &p4_v1.Entity_DigestEntry{entry},
+			Entity: &p4_v1.Entity_DigestEntry{DigestEntry: entry},
 		},
 	}
 	return c.WriteUpdate(update)
@@ -39,7 +39,7 @@ func (c *Client) ModifyDigest(digest string, config *p4_v1.DigestEntry_Config) e
 	update := &p4_v1.Update{
 		Type: p4_v1.Update_MODIFY,
 		Entity: &p4_v1.Entity{
-			Entity: &p4_v1.Entity_DigestEntry{entry},
+			Entity: &p4_v1.Entity_DigestEntry{DigestEntry: entry},
 		},
 	}
 	return c.WriteUpdate(update)
@@ -53,7 +53,7 @@ func (c *Client) DisableDigest(digest string) error {
 	update := &p4_v1.Update{
 		Type: p4_v1.Update_DELETE,
 		Entity: &p4_v1.Entity{
-			Entity: &p4_v1.Entity_DigestEntry{entry},
+			Entity: &p4_v1.Entity_DigestEntry{DigestEntry: entry},
 		},
 	}
 	return c.WriteUpdate(update)

--- a/pkg/client/pre.go
+++ b/pkg/client/pre.go
@@ -18,7 +18,7 @@ func (c *Client) InsertMulticastGroup(mgid uint32, ports []uint32) error {
 
 	preEntry := &p4_v1.PacketReplicationEngineEntry{
 		Type: &p4_v1.PacketReplicationEngineEntry_MulticastGroupEntry{
-			entry,
+			MulticastGroupEntry: entry,
 		},
 	}
 
@@ -27,7 +27,9 @@ func (c *Client) InsertMulticastGroup(mgid uint32, ports []uint32) error {
 	update := &p4_v1.Update{
 		Type: updateType,
 		Entity: &p4_v1.Entity{
-			Entity: &p4_v1.Entity_PacketReplicationEngineEntry{preEntry},
+			Entity: &p4_v1.Entity_PacketReplicationEngineEntry{
+				PacketReplicationEngineEntry: preEntry,
+			},
 		},
 	}
 
@@ -41,7 +43,7 @@ func (c *Client) DeleteMulticastGroup(mgid uint32) error {
 
 	preEntry := &p4_v1.PacketReplicationEngineEntry{
 		Type: &p4_v1.PacketReplicationEngineEntry_MulticastGroupEntry{
-			entry,
+			MulticastGroupEntry: entry,
 		},
 	}
 
@@ -50,7 +52,9 @@ func (c *Client) DeleteMulticastGroup(mgid uint32) error {
 	update := &p4_v1.Update{
 		Type: updateType,
 		Entity: &p4_v1.Entity{
-			Entity: &p4_v1.Entity_PacketReplicationEngineEntry{preEntry},
+			Entity: &p4_v1.Entity_PacketReplicationEngineEntry{
+				PacketReplicationEngineEntry: preEntry,
+			},
 		},
 	}
 

--- a/pkg/client/tables.go
+++ b/pkg/client/tables.go
@@ -56,6 +56,57 @@ func (m *LpmMatch) get(ID uint32) *p4_v1.FieldMatch {
 	return mf
 }
 
+type TernaryMatch struct {
+	Value []byte
+	Mask  []byte
+}
+
+func (m *TernaryMatch) get(ID uint32) *p4_v1.FieldMatch {
+	ternary := &p4_v1.FieldMatch_Ternary{
+		Value: m.Value,
+		Mask:  m.Mask,
+	}
+	mf := &p4_v1.FieldMatch{
+		FieldId:        ID,
+		FieldMatchType: &p4_v1.FieldMatch_Ternary_{ternary},
+	}
+	return mf
+}
+
+type RangeMatch struct {
+	Low  []byte
+	High []byte
+}
+
+func (m *RangeMatch) get(ID uint32) *p4_v1.FieldMatch {
+	fmRange := &p4_v1.FieldMatch_Range{
+		Low:  m.Low,
+		High: m.High,
+	}
+
+	mf := &p4_v1.FieldMatch{
+		FieldId:        ID,
+		FieldMatchType: &p4_v1.FieldMatch_Range_{fmRange},
+	}
+	return mf
+}
+
+type OptionalMatch struct {
+	Value []byte
+}
+
+func (m *OptionalMatch) get(ID uint32) *p4_v1.FieldMatch {
+	optional := &p4_v1.FieldMatch_Optional{
+		Value: m.Value,
+	}
+
+	mf := &p4_v1.FieldMatch{
+		FieldId:        ID,
+		FieldMatchType: &p4_v1.FieldMatch_Optional_{optional},
+	}
+	return mf
+}
+
 type TableEntryOptions struct {
 	IdleTimeout time.Duration
 }

--- a/pkg/client/tables.go
+++ b/pkg/client/tables.go
@@ -20,7 +20,7 @@ func (m *ExactMatch) get(ID uint32) *p4_v1.FieldMatch {
 	}
 	mf := &p4_v1.FieldMatch{
 		FieldId:        ID,
-		FieldMatchType: &p4_v1.FieldMatch_Exact_{exact},
+		FieldMatchType: &p4_v1.FieldMatch_Exact_{Exact: exact},
 	}
 	return mf
 }
@@ -51,7 +51,7 @@ func (m *LpmMatch) get(ID uint32) *p4_v1.FieldMatch {
 
 	mf := &p4_v1.FieldMatch{
 		FieldId:        ID,
-		FieldMatchType: &p4_v1.FieldMatch_Lpm{lpm},
+		FieldMatchType: &p4_v1.FieldMatch_Lpm{Lpm: lpm},
 	}
 	return mf
 }
@@ -68,7 +68,7 @@ func (m *TernaryMatch) get(ID uint32) *p4_v1.FieldMatch {
 	}
 	mf := &p4_v1.FieldMatch{
 		FieldId:        ID,
-		FieldMatchType: &p4_v1.FieldMatch_Ternary_{ternary},
+		FieldMatchType: &p4_v1.FieldMatch_Ternary_{Ternary: ternary},
 	}
 	return mf
 }
@@ -86,7 +86,7 @@ func (m *RangeMatch) get(ID uint32) *p4_v1.FieldMatch {
 
 	mf := &p4_v1.FieldMatch{
 		FieldId:        ID,
-		FieldMatchType: &p4_v1.FieldMatch_Range_{fmRange},
+		FieldMatchType: &p4_v1.FieldMatch_Range_{Range: fmRange},
 	}
 	return mf
 }
@@ -102,7 +102,7 @@ func (m *OptionalMatch) get(ID uint32) *p4_v1.FieldMatch {
 
 	mf := &p4_v1.FieldMatch{
 		FieldId:        ID,
-		FieldMatchType: &p4_v1.FieldMatch_Optional_{optional},
+		FieldMatchType: &p4_v1.FieldMatch_Optional_{Optional: optional},
 	}
 	return mf
 }
@@ -133,7 +133,7 @@ func (c *Client) NewTableActionDirect(
 	params [][]byte,
 ) *p4_v1.TableAction {
 	return &p4_v1.TableAction{
-		Type: &p4_v1.TableAction_Action{c.newAction(action, params)},
+		Type: &p4_v1.TableAction_Action{Action: c.newAction(action, params)},
 	}
 }
 
@@ -146,7 +146,9 @@ func (c *Client) NewActionProfileActionSet() *ActionProfileActionSet {
 	return &ActionProfileActionSet{
 		client: c,
 		action: &p4_v1.TableAction{
-			Type: &p4_v1.TableAction_ActionProfileActionSet{&p4_v1.ActionProfileActionSet{}},
+			Type: &p4_v1.TableAction_ActionProfileActionSet{
+				ActionProfileActionSet: &p4_v1.ActionProfileActionSet{},
+			},
 		},
 	}
 }
@@ -161,9 +163,11 @@ func (s *ActionProfileActionSet) AddAction(
 	actionSet.ActionProfileActions = append(
 		actionSet.ActionProfileActions,
 		&p4_v1.ActionProfileAction{
-			Action:    s.client.newAction(action, params),
-			Weight:    weight,
-			WatchKind: &p4_v1.ActionProfileAction_WatchPort{port.AsBytes()},
+			Action: s.client.newAction(action, params),
+			Weight: weight,
+			WatchKind: &p4_v1.ActionProfileAction_WatchPort{
+				WatchPort: port.AsBytes(),
+			},
 		},
 	)
 	return s
@@ -204,7 +208,7 @@ func (c *Client) InsertTableEntry(entry *p4_v1.TableEntry) error {
 	update := &p4_v1.Update{
 		Type: p4_v1.Update_INSERT,
 		Entity: &p4_v1.Entity{
-			Entity: &p4_v1.Entity_TableEntry{entry},
+			Entity: &p4_v1.Entity_TableEntry{TableEntry: entry},
 		},
 	}
 
@@ -215,7 +219,7 @@ func (c *Client) ModifyTableEntry(entry *p4_v1.TableEntry) error {
 	update := &p4_v1.Update{
 		Type: p4_v1.Update_MODIFY,
 		Entity: &p4_v1.Entity{
-			Entity: &p4_v1.Entity_TableEntry{entry},
+			Entity: &p4_v1.Entity_TableEntry{TableEntry: entry},
 		},
 	}
 
@@ -226,7 +230,7 @@ func (c *Client) DeleteTableEntry(entry *p4_v1.TableEntry) error {
 	update := &p4_v1.Update{
 		Type: p4_v1.Update_DELETE,
 		Entity: &p4_v1.Entity{
-			Entity: &p4_v1.Entity_TableEntry{entry},
+			Entity: &p4_v1.Entity_TableEntry{TableEntry: entry},
 		},
 	}
 


### PR DESCRIPTION
Hi Antonin!

The first commit in this PR adds Ternary, Range and Optional matches.

I added a 2nd commit to this PR that changes some composite literal creation to keyed fields as VSCode (go vet) gives 'composite literal uses unkeyed fields' warnings if no keyed fields are used. I've learned that using unkeyed fields could give problems if the order of fields is changed in the future (that could happen with proto generated code).

If you are not ok with this 2nd commit you could cherry-pick the first commit or I can remove it from this PR, what you want!