### PR TITLE
Default to canonical representation for binary strings

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -16,7 +16,20 @@ const (
 	P4RuntimePort = 9559
 )
 
+type ClientOptions struct {
+	CanonicalBytestrings bool
+}
+
+var defaultClientOptions = ClientOptions{
+	CanonicalBytestrings: true,
+}
+
+func DisableCanonicalBytestrings(options *ClientOptions) {
+	options.CanonicalBytestrings = false
+}
+
 type Client struct {
+	ClientOptions
 	p4_v1.P4RuntimeClient
 	deviceID     uint64
 	electionID   p4_v1.Uint128
@@ -24,8 +37,18 @@ type Client struct {
 	streamSendCh chan *p4_v1.StreamMessageRequest
 }
 
-func NewClient(p4RuntimeClient p4_v1.P4RuntimeClient, deviceID uint64, electionID p4_v1.Uint128) *Client {
+func NewClient(
+	p4RuntimeClient p4_v1.P4RuntimeClient,
+	deviceID uint64,
+	electionID p4_v1.Uint128,
+	optionsModifierFns ...func(*ClientOptions),
+) *Client {
+	options := defaultClientOptions
+	for _, fn := range optionsModifierFns {
+		fn(&options)
+	}
 	return &Client{
+		ClientOptions:   options,
 		P4RuntimeClient: p4RuntimeClient,
 		deviceID:        deviceID,
 		electionID:      electionID,

--- a/pkg/client/tables_test.go
+++ b/pkg/client/tables_test.go
@@ -1,0 +1,105 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const mfID = 1
+
+func TestExactMatch(t *testing.T) {
+	testCases := []struct {
+		canonical bool
+		in        []byte
+		out       []byte
+	}{
+		{true, []byte{'\x00', '\xab'}, []byte{'\xab'}},
+		{false, []byte{'\x00', '\xab'}, []byte{'\x00', '\xab'}},
+	}
+
+	for _, tc := range testCases {
+		m := ExactMatch{Value: tc.in}
+		mf := m.get(mfID, tc.canonical)
+		assert.Equal(t, tc.out, mf.GetExact().Value)
+	}
+}
+
+func TestLPMMatch(t *testing.T) {
+	testCases := []struct {
+		canonical bool
+		in        []byte
+		pLen      int32
+		out       []byte
+	}{
+		{true, []byte{'\x00', '\xab'}, 16, []byte{'\xab'}},
+		{false, []byte{'\x00', '\xab'}, 16, []byte{'\x00', '\xab'}},
+		{true, []byte{'\x00', '\xab'}, 8, []byte{'\x00'}},
+	}
+
+	for _, tc := range testCases {
+		m := LpmMatch{Value: tc.in, PLen: tc.pLen}
+		mf := m.get(mfID, tc.canonical)
+		assert.Equal(t, tc.out, mf.GetLpm().Value)
+		assert.Equal(t, tc.pLen, mf.GetLpm().PrefixLen)
+	}
+}
+
+func TestTernaryMatch(t *testing.T) {
+	testCases := []struct {
+		canonical bool
+		valueIn   []byte
+		maskIn    []byte
+		valueOut  []byte
+		maskOut   []byte
+	}{
+		{true, []byte{'\x00', '\xab'}, []byte{'\x00', '\xf0'}, []byte{'\xa0'}, []byte{'\xf0'}},
+		{false, []byte{'\x00', '\xab'}, []byte{'\x00', '\xf0'}, []byte{'\x00', '\xa0'}, []byte{'\x00', '\xf0'}},
+		{true, []byte{'\xab', '\x00'}, []byte{'\xff'}, []byte{'\x00'}, []byte{'\xff'}},
+		{true, []byte{'\xab'}, []byte{'\x0f', '\x0f'}, []byte{'\x0b'}, []byte{'\x0f', '\x0f'}},
+	}
+
+	for _, tc := range testCases {
+		m := TernaryMatch{Value: tc.valueIn, Mask: tc.maskIn}
+		mf := m.get(mfID, tc.canonical)
+		assert.Equal(t, tc.valueOut, mf.GetTernary().Value)
+		assert.Equal(t, tc.maskOut, mf.GetTernary().Mask)
+	}
+}
+
+func TestRangeMatch(t *testing.T) {
+	testCases := []struct {
+		canonical bool
+		lowIn     []byte
+		highIn    []byte
+		lowOut    []byte
+		highOut   []byte
+	}{
+		{true, []byte{'\x00', '\xab'}, []byte{'\xff', '\xf0'}, []byte{'\xab'}, []byte{'\xff', '\xf0'}},
+		{false, []byte{'\x00', '\xab'}, []byte{'\xff', '\xf0'}, []byte{'\x00', '\xab'}, []byte{'\xff', '\xf0'}},
+	}
+
+	for _, tc := range testCases {
+		m := RangeMatch{Low: tc.lowIn, High: tc.highIn}
+		mf := m.get(mfID, tc.canonical)
+		assert.Equal(t, tc.lowOut, mf.GetRange().Low)
+		assert.Equal(t, tc.highOut, mf.GetRange().High)
+	}
+}
+
+func TestOptionalMatch(t *testing.T) {
+	testCases := []struct {
+		canonical bool
+		in        []byte
+		out       []byte
+	}{
+		{true, []byte{'\x00', '\xab'}, []byte{'\xab'}},
+		{false, []byte{'\x00', '\xab'}, []byte{'\x00', '\xab'}},
+	}
+
+	for _, tc := range testCases {
+		m := OptionalMatch{Value: tc.in}
+		mf := m.get(mfID, tc.canonical)
+		assert.Equal(t, tc.out, mf.GetOptional().Value)
+	}
+}

--- a/pkg/util/conversion/conversion.go
+++ b/pkg/util/conversion/conversion.go
@@ -38,3 +38,20 @@ func UInt32ToBinaryCompressed(i uint32) ([]byte, error) {
 	}
 	return []byte{'\x00'}, nil
 }
+
+func ToCanonicalBytestring(bytes []byte) []byte {
+	if len(bytes) == 0 {
+		return bytes
+	}
+	i := 0
+	for _, b := range bytes {
+		if b != 0 {
+			break
+		}
+		i++
+	}
+	if i == len(bytes) {
+		return bytes[:1]
+	}
+	return bytes[i:]
+}

--- a/pkg/util/conversion/conversion_test.go
+++ b/pkg/util/conversion/conversion_test.go
@@ -21,3 +21,24 @@ func TestUInt32ToBinaryCompressed(t *testing.T) {
 		assert.Equal(t, tc.out, out)
 	}
 }
+
+func TestToCanonicalBytestring(t *testing.T) {
+	testCases := []struct {
+		in  []byte
+		out []byte
+	}{
+		{nil, nil},
+		{[]byte{}, []byte{}},
+		{[]byte{'\x00'}, []byte{'\x00'}},
+		{[]byte{'\x00', '\x00', '\x00'}, []byte{'\x00'}},
+		{[]byte{'\xab'}, []byte{'\xab'}},
+		{[]byte{'\x0a'}, []byte{'\x0a'}},
+		{[]byte{'\x00', '\xab'}, []byte{'\xab'}},
+		{[]byte{'\xab', '\x00', '\xcd', '\x00'}, []byte{'\xab', '\x00', '\xcd', '\x00'}},
+	}
+
+	for _, tc := range testCases {
+		out := ToCanonicalBytestring(tc.in)
+		assert.Equal(t, tc.out, out)
+	}
+}


### PR DESCRIPTION
With the possibility to fall back to the legacy, byte-padded format when
initializing the Client.