### PR TITLE
Add golangci-lint to Github CI step

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -36,3 +36,18 @@ jobs:
     - name: Check tidiness
       run: |
         ./ci/check-tidy.sh
+
+  golangci:
+    name: lint
+    runs-on: [ubuntu-latest]
+    steps:
+    - uses: actions/checkout@v2
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v2
+      with:
+        # Required: the version of golangci-lint is required and must be specified without patch version:
+        # we always use the latest patch version. Keep this version the same with the one in the Makefile!!
+        version: v1.40
+
+        # Optional: show only new issues if it's a pull request. The default value is `false`.
+        only-new-issues: false

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ bin/
 .bins
 
 *.pyc
+
+# Go code linting program
+.golangci-bin

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,24 @@
+run:
+  tests: true
+  timeout: 5m
+  skip-files:
+    - ".*\\.pb\\.go"
+  skip-dirs-use-default: true
+
+linters-settings:
+  goimports:
+    local-prefixes: github.com/antoninbas/p4runtime-go-client/
+
+linters:
+  disable-all: true
+  enable: # see https://golangci-lint.run/usage/linters/
+    - deadcode
+    - staticcheck
+    - govet
+    - gofmt
+    - goimports
+    - gosec
+    - misspell
+
+run:
+  deadline: 5m

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ bin:
 clean:
 	rm -rf bin
 	rm -rf .bins
+	rm -rf .golangci-bin
 
 .PHONY: fmt
 fmt:
@@ -37,3 +38,18 @@ check-unit:
 .PHONY: check
 check:
 	$(GO) test -tags=integration github.com/antoninbas/p4runtime-go-client/...
+
+# code linting
+.golangci-bin:
+	@echo "===> Installing Golangci-lint <==="
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $@ v1.40.0
+
+.PHONY: golangci
+golangci: .golangci-bin
+	@echo "===> Running golangci <==="
+	@GOOS=linux .golangci-bin/golangci-lint run -c .golangci.yml
+
+.PHONY: golangci-fix
+golangci-fix: .golangci-bin
+	@echo "===> Running golangci-fix <==="
+	@GOOS=linux .golangci-bin/golangci-lint run -c .golangci.yml --fix

--- a/cmd/l2_switch/main.go
+++ b/cmd/l2_switch/main.go
@@ -100,7 +100,9 @@ func learnMacs(p4RtC *client.Client, digestList *p4_v1.DigestList) error {
 
 		smacEntry := p4RtC.NewTableEntry(
 			"IngressImpl.smac",
-			[]client.MatchInterface{&client.ExactMatch{srcAddr}},
+			[]client.MatchInterface{&client.ExactMatch{
+				Value: srcAddr,
+			}},
 			p4RtC.NewTableActionDirect("NoAction", nil),
 			smacOptions,
 		)
@@ -110,7 +112,9 @@ func learnMacs(p4RtC *client.Client, digestList *p4_v1.DigestList) error {
 
 		dmacEntry := p4RtC.NewTableEntry(
 			"IngressImpl.dmac",
-			[]client.MatchInterface{&client.ExactMatch{srcAddr}},
+			[]client.MatchInterface{&client.ExactMatch{
+				Value: srcAddr,
+			}},
 			p4RtC.NewTableActionDirect("IngressImpl.fwd", [][]byte{ingressPort}),
 			nil,
 		)
@@ -138,7 +142,9 @@ func forgetEntries(p4RtC *client.Client, notification *p4_v1.IdleTimeoutNotifica
 
 		dmacEntry := p4RtC.NewTableEntry(
 			"IngressImpl.dmac",
-			[]client.MatchInterface{&client.ExactMatch{srcAddr}},
+			[]client.MatchInterface{&client.ExactMatch{
+				Value: srcAddr,
+			}},
 			nil,
 			nil,
 		)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -107,11 +107,9 @@ func (c *Client) Run(
 		case m := <-c.streamSendCh:
 			stream.Send(m)
 		case <-stopCh:
-			break
+			return nil
 		}
 	}
-
-	return nil
 }
 
 func (c *Client) WriteUpdate(update *p4_v1.Update) error {

--- a/pkg/client/counters.go
+++ b/pkg/client/counters.go
@@ -37,7 +37,7 @@ func (c *Client) ReadCounterEntry(counter string, index int64) (*p4_v1.CounterDa
 	}
 	readEntry := readEntity.GetCounterEntry()
 	if readEntry == nil {
-		return nil, fmt.Errorf("server returned an entity but it is not a counter entry!")
+		return nil, fmt.Errorf("server returned an entity but it is not a counter entry! ")
 	}
 	return readEntry.Data, nil
 }
@@ -57,7 +57,8 @@ func (c *Client) ReadCounterEntryWildcard(counter string) ([]*p4_v1.CounterData,
 		for readEntity := range readEntityCh {
 			readEntry := readEntity.GetCounterEntry()
 			if readEntry == nil {
-				err = fmt.Errorf("server returned an entity which is not a counter entry!")
+				err = fmt.Errorf("server returned an entity which is not a counter entry! ")
+				break
 			}
 			out = append(out, readEntry.Data)
 		}

--- a/pkg/client/fwd_pipe.go
+++ b/pkg/client/fwd_pipe.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	//nolint:staticcheck // SA1019 To be resolved later
+	//lint:ignore SA1019 This line added for support golint version of VSC
 	"github.com/golang/protobuf/proto"
 
 	p4_config_v1 "github.com/p4lang/p4runtime/go/p4/config/v1"

--- a/pkg/client/pre.go
+++ b/pkg/client/pre.go
@@ -22,8 +22,7 @@ func (c *Client) InsertMulticastGroup(mgid uint32, ports []uint32) error {
 		},
 	}
 
-	var updateType p4_v1.Update_Type
-	updateType = p4_v1.Update_INSERT
+	updateType := p4_v1.Update_INSERT
 	update := &p4_v1.Update{
 		Type: updateType,
 		Entity: &p4_v1.Entity{
@@ -47,8 +46,7 @@ func (c *Client) DeleteMulticastGroup(mgid uint32) error {
 		},
 	}
 
-	var updateType p4_v1.Update_Type
-	updateType = p4_v1.Update_DELETE
+	updateType := p4_v1.Update_DELETE
 	update := &p4_v1.Update{
 		Type: updateType,
 		Entity: &p4_v1.Entity{

--- a/pkg/client/tables.go
+++ b/pkg/client/tables.go
@@ -215,11 +215,14 @@ func (c *Client) NewTableEntry(
 	tableID := c.tableId(table)
 
 	entry := &p4_v1.TableEntry{
-		TableId:         tableID,
+		TableId: tableID,
+		//nolint:staticcheck // SA5011 if mfs==nil then for loop is not executed by default
 		IsDefaultAction: (mfs == nil),
 		Action:          action,
 	}
 
+	//nolint:staticcheck // SA5011 if mfs==nil then for loop is not executed by default
+	//lint:ignore SA5011 This line added for support golint version of VSC
 	for idx, mf := range mfs {
 		entry.Match = append(entry.Match, mf.get(uint32(idx+1), c.CanonicalBytestrings))
 	}


### PR DESCRIPTION
@antoninbas First stab it implementing golangci-lint. Just basic use of the action but the CI run on this PR on my fork already gave a lot of errors (see the list below). We need to find out which options (defined in .golangci.yml) are reasonable and which not. There are also a lot of other options related to errors showing up in the checked PR I do not understand yet. Will play with it a little longer.

Do not merge as I put my local PR branch in the go.yml... 

*Current Error list:* 
```
  Error: Error return value of `stream.CloseSend` is not checked (errcheck)
  Error: Error return value of `stream.Send` is not checked (errcheck)
  Error: Error return value of `stream.Send` is not checked (errcheck)
  Error: Error return value of `p4RtC.Run` is not checked (errcheck)
  Error: Error return value of `p4RtC.Run` is not checked (errcheck)
  Error: func IpToBinary should be IPToBinary (golint)
  Error: type name will be used as client.ClientOptions by other packages, and that stutters; consider calling this Options (golint)
  Error: error strings should not be capitalized or end with punctuation or a newline (golint)
  Error: error strings should not be capitalized or end with punctuation or a newline (golint)
  Error: method tableId should be tableID (golint)
  Error: method actionId should be actionID (golint)
  Error: method digestId should be digestID (golint)
  Error: method counterId should be counterID (golint)
  Error: `if` block ends with a `return` statement, so drop this `else` and outdent its block (golint)
  Error: line is 133 characters (lll)
  Error: struct of size 64 bytes could be of size 56 bytes (maligned)
  Error: S1021: should merge variable declaration with assignment on next line (gosimple)
  Error: S1021: should merge variable declaration with assignment on next line (gosimple)
  Error: composites: `github.com/antoninbas/p4runtime-go-client/pkg/client.ExactMatch` composite literal uses unkeyed fields (govet)
  Error: composites: `github.com/antoninbas/p4runtime-go-client/pkg/client.ExactMatch` composite literal uses unkeyed fields (govet)
  Error: composites: `github.com/antoninbas/p4runtime-go-client/pkg/client.ExactMatch` composite literal uses unkeyed fields (govet)
  Error: unreachable: unreachable code (govet)
  Error: SA1019: package github.com/golang/protobuf/proto is deprecated: Use the "google.golang.org/protobuf/proto" package instead.  (staticcheck)
  Error: SA4017: Errorf is a pure function but its return value is ignored (staticcheck)
  Error: SA5011: possible nil pointer dereference (staticcheck)
```
  