### PR TITLE
Implement GetFwdPipe, add Cookie to SetFwdPipe

### DIFF
--- a/cmd/example/main.go
+++ b/cmd/example/main.go
@@ -88,7 +88,7 @@ func main() {
 	}
 
 	log.Info("Setting forwarding pipe")
-	if err := p4RtC.SetFwdPipe(binPath, p4infoPath); err != nil {
+	if _, err := p4RtC.SetFwdPipe(binPath, p4infoPath, 0); err != nil {
 		log.Fatalf("Error when setting forwarding pipe: %v", err)
 	}
 

--- a/cmd/l2_switch/main.go
+++ b/cmd/l2_switch/main.go
@@ -316,7 +316,7 @@ func main() {
 	}
 
 	log.Info("Setting forwarding pipe")
-	if err := p4RtC.SetFwdPipeFromBytes(binBytes, p4infoBytes); err != nil {
+	if _, err := p4RtC.SetFwdPipeFromBytes(binBytes, p4infoBytes, 0); err != nil {
 		log.Fatalf("Error when setting forwarding pipe: %v", err)
 	}
 

--- a/pkg/client/fwd_pipe.go
+++ b/pkg/client/fwd_pipe.go
@@ -11,15 +11,25 @@ import (
 	p4_v1 "github.com/p4lang/p4runtime/go/p4/v1"
 )
 
-func (c *Client) SetFwdPipeFromBytes(binBytes, p4infoBytes []byte) error {
+type FwdPipeConfig struct {
+	P4Info         *p4_config_v1.P4Info
+	P4DeviceConfig []byte
+	Cookie         uint64
+}
+
+func (c *Client) SetFwdPipeFromBytes(binBytes, p4infoBytes []byte, cookie uint64) (*FwdPipeConfig, error) {
 	p4Info := &p4_config_v1.P4Info{}
 	if err := proto.UnmarshalText(string(p4infoBytes), p4Info); err != nil {
-		return fmt.Errorf("failed to decode P4Info Protobuf message: %v", err)
+		return nil, fmt.Errorf("failed to decode P4Info Protobuf message: %v", err)
 	}
 	config := &p4_v1.ForwardingPipelineConfig{
 		P4Info:         p4Info,
 		P4DeviceConfig: binBytes,
+		Cookie: &p4_v1.ForwardingPipelineConfig_Cookie{
+			Cookie: cookie,
+		},
 	}
+
 	req := &p4_v1.SetForwardingPipelineConfigRequest{
 		DeviceId:   c.deviceID,
 		ElectionId: &c.electionID,
@@ -29,18 +39,71 @@ func (c *Client) SetFwdPipeFromBytes(binBytes, p4infoBytes []byte) error {
 	_, err := c.SetForwardingPipelineConfig(context.Background(), req)
 	if err == nil {
 		c.p4Info = p4Info
+		return &FwdPipeConfig{
+			P4Info:         p4Info,
+			P4DeviceConfig: binBytes,
+			Cookie:         cookie,
+		}, nil
 	}
-	return err
+
+	return nil, err
 }
 
-func (c *Client) SetFwdPipe(binPath string, p4infoPath string) error {
+func (c *Client) SetFwdPipe(binPath string, p4infoPath string, cookie uint64) (*FwdPipeConfig, error) {
 	binBytes, err := ioutil.ReadFile(binPath)
 	if err != nil {
-		return fmt.Errorf("error when reading binary device config: %v", err)
+		return nil, fmt.Errorf("error when reading binary device config: %v", err)
 	}
 	p4infoBytes, err := ioutil.ReadFile(p4infoPath)
 	if err != nil {
-		return fmt.Errorf("error when reading P4Info text file: %v", err)
+		return nil, fmt.Errorf("error when reading P4Info text file: %v", err)
 	}
-	return c.SetFwdPipeFromBytes(binBytes, p4infoBytes)
+	return c.SetFwdPipeFromBytes(binBytes, p4infoBytes, cookie)
+}
+
+type GetFwdPipeResponseType int32
+
+const (
+	GetFwdPipeAll                   = GetFwdPipeResponseType(p4_v1.GetForwardingPipelineConfigRequest_ALL)
+	GetFwdPipeCookieOnly            = GetFwdPipeResponseType(p4_v1.GetForwardingPipelineConfigRequest_COOKIE_ONLY)
+	GetFwdPipeP4InfoAndCookie       = GetFwdPipeResponseType(p4_v1.GetForwardingPipelineConfigRequest_P4INFO_AND_COOKIE)
+	GetFwdPipeDeviceConfigAndCookie = GetFwdPipeResponseType(p4_v1.GetForwardingPipelineConfigRequest_DEVICE_CONFIG_AND_COOKIE)
+)
+
+// GetFwdPipe retrieves the current pipeline config used in the remote switch.
+//
+// responseType is oneof:
+//  GetFwdPipeAll, GetFwdPipeCookieOnly, GetFwdPipeP4InfoAndCookie, GetFwdPipeDeviceConfigAndCookie
+// See https://p4.org/p4runtime/spec/v1.3.0/P4Runtime-Spec.html#sec-getforwardingpipelineconfig-rpc
+func (c *Client) GetFwdPipe(responseType GetFwdPipeResponseType) (*FwdPipeConfig, error) {
+	req := &p4_v1.GetForwardingPipelineConfigRequest{
+		DeviceId:     c.deviceID,
+		ResponseType: p4_v1.GetForwardingPipelineConfigRequest_ResponseType(responseType),
+	}
+
+	resp, err := c.GetForwardingPipelineConfig(context.Background(), req)
+	if err != nil {
+		return nil, fmt.Errorf("error when retrieving forwardingpipeline config: %v", err)
+	}
+
+	config := resp.GetConfig()
+	if config == nil {
+		// pipeline doesn't have a config yet
+		return nil, nil
+	}
+
+	var pipeConfig = &FwdPipeConfig{
+		P4Info:         config.GetP4Info(),
+		P4DeviceConfig: config.GetP4DeviceConfig(),
+	}
+	if Cookie := config.GetCookie(); Cookie != nil {
+		pipeConfig.Cookie = Cookie.GetCookie()
+	}
+
+	// save P4info for later use
+	if pipeConfig.P4Info != nil {
+		c.p4Info = pipeConfig.P4Info
+	}
+
+	return pipeConfig, nil
 }


### PR DESCRIPTION
Also return a FwdPipeConfig struct from all three functions with the applied or retrieved pipe configuration.

I added the return of the struct also to the SetFwdPipe and SetFwdPipeFromBytes because I want to add a P4Info API to this set and get returns in a follow up PR. If not ok I can remove that from the "Setxxx" functions for now.