### PR TITLE
Add support for reading table entries

### DIFF
--- a/pkg/client/tables.go
+++ b/pkg/client/tables.go
@@ -267,7 +267,6 @@ func (c *Client) ReadTableEntry(table string, mfs []MatchInterface) (*p4_v1.Tabl
 func (c *Client) ReadTableEntryWildcard(table string) ([]*p4_v1.TableEntry, error) {
 	tableID := c.tableId(table)
 
-	fmt.Println("Table ID = ", tableID)
 	entry := &p4_v1.TableEntry{
 		TableId: tableID,
 	}

--- a/pkg/client/tables.go
+++ b/pkg/client/tables.go
@@ -240,6 +240,7 @@ func (c *Client) ReadTableEntry(table string, mfs []MatchInterface) (*p4_v1.Tabl
 
 	entry := &p4_v1.TableEntry{
 		TableId: tableID,
+		Priority: 0,
 	}
 
 	for idx, mf := range mfs {

--- a/pkg/client/tables.go
+++ b/pkg/client/tables.go
@@ -136,6 +136,7 @@ func (m *OptionalMatch) get(ID uint32, canonical bool) *p4_v1.FieldMatch {
 
 type TableEntryOptions struct {
 	IdleTimeout time.Duration
+	Priority    int32
 }
 
 func (c *Client) newAction(action string, params [][]byte) *p4_v1.Action {
@@ -219,6 +220,7 @@ func (c *Client) NewTableEntry(
 		//nolint:staticcheck // SA5011 if mfs==nil then for loop is not executed by default
 		IsDefaultAction: (mfs == nil),
 		Action:          action,
+		Priority:        0,
 	}
 
 	//nolint:staticcheck // SA5011 if mfs==nil then for loop is not executed by default
@@ -228,6 +230,7 @@ func (c *Client) NewTableEntry(
 	}
 
 	if options != nil {
+		entry.Priority = options.Priority
 		entry.IdleTimeoutNs = options.IdleTimeout.Nanoseconds()
 	}
 


### PR DESCRIPTION
This PR implements `ReadTableEntry` and `ReadTableEntryWildcard`. Even though it's possible to generate a read request using a current version of p4runtime-go-client, I believe it's better to have a user-friendly API. 