### PR TITLE
Fix indefinite blocking when reading wildcard entities

### DIFF
--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1,0 +1,90 @@
+package client
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+
+	p4_config_v1 "github.com/p4lang/p4runtime/go/p4/config/v1"
+	p4_v1 "github.com/p4lang/p4runtime/go/p4/v1"
+)
+
+type fakeP4RuntimeClient struct {
+	writeFn                       func(ctx context.Context, in *p4_v1.WriteRequest, opts ...grpc.CallOption) (*p4_v1.WriteResponse, error)
+	readFn                        func(ctx context.Context, in *p4_v1.ReadRequest, opts ...grpc.CallOption) (p4_v1.P4Runtime_ReadClient, error)
+	setForwardingPipelineConfigFn func(ctx context.Context, in *p4_v1.SetForwardingPipelineConfigRequest, opts ...grpc.CallOption) (*p4_v1.SetForwardingPipelineConfigResponse, error)
+	getForwardingPipelineConfigFn func(ctx context.Context, in *p4_v1.GetForwardingPipelineConfigRequest, opts ...grpc.CallOption) (*p4_v1.GetForwardingPipelineConfigResponse, error)
+	streamChannelFn               func(ctx context.Context, opts ...grpc.CallOption) (p4_v1.P4Runtime_StreamChannelClient, error)
+	capabilitiesFn                func(ctx context.Context, in *p4_v1.CapabilitiesRequest, opts ...grpc.CallOption) (*p4_v1.CapabilitiesResponse, error)
+}
+
+// fakeP4RuntimeClient implements the p4_v1.P4RuntimeClient interface
+var _ p4_v1.P4RuntimeClient = &fakeP4RuntimeClient{}
+
+func (c *fakeP4RuntimeClient) Write(ctx context.Context, in *p4_v1.WriteRequest, opts ...grpc.CallOption) (*p4_v1.WriteResponse, error) {
+	if c.writeFn == nil {
+		panic("No mock defined for Write RPC")
+	}
+	return c.writeFn(ctx, in, opts...)
+}
+
+func (c *fakeP4RuntimeClient) Read(ctx context.Context, in *p4_v1.ReadRequest, opts ...grpc.CallOption) (p4_v1.P4Runtime_ReadClient, error) {
+	if c.readFn == nil {
+		panic("No mock defined for Read RPC")
+	}
+	return c.readFn(ctx, in, opts...)
+}
+
+func (c *fakeP4RuntimeClient) SetForwardingPipelineConfig(ctx context.Context, in *p4_v1.SetForwardingPipelineConfigRequest, opts ...grpc.CallOption) (*p4_v1.SetForwardingPipelineConfigResponse, error) {
+	if c.setForwardingPipelineConfigFn == nil {
+		panic("No mock defined for SetForwardingPipelineConfig RPC")
+	}
+	return c.setForwardingPipelineConfigFn(ctx, in, opts...)
+}
+
+func (c *fakeP4RuntimeClient) GetForwardingPipelineConfig(ctx context.Context, in *p4_v1.GetForwardingPipelineConfigRequest, opts ...grpc.CallOption) (*p4_v1.GetForwardingPipelineConfigResponse, error) {
+	if c.getForwardingPipelineConfigFn == nil {
+		panic("No mock defined for GetForwardingPipelineConfig RPC")
+	}
+	return c.getForwardingPipelineConfigFn(ctx, in, opts...)
+}
+
+func (c *fakeP4RuntimeClient) StreamChannel(ctx context.Context, opts ...grpc.CallOption) (p4_v1.P4Runtime_StreamChannelClient, error) {
+	if c.streamChannelFn == nil {
+		panic("No mock defined for StreamChannel")
+	}
+	return c.streamChannelFn(ctx, opts...)
+}
+
+func (c *fakeP4RuntimeClient) Capabilities(ctx context.Context, in *p4_v1.CapabilitiesRequest, opts ...grpc.CallOption) (*p4_v1.CapabilitiesResponse, error) {
+	if c.capabilitiesFn == nil {
+		panic("No mock defined for Capabilities RPC")
+	}
+	return c.capabilitiesFn(ctx, in, opts...)
+}
+
+type fakeP4RuntimeReadClient struct {
+	grpc.ClientStream
+	recvFn func() (*p4_v1.ReadResponse, error)
+}
+
+// fakeP4RuntimeReadClient implements the p4_v1.P4Runtime_ReadClient interface
+var _ p4_v1.P4Runtime_ReadClient = &fakeP4RuntimeReadClient{}
+
+func (c *fakeP4RuntimeReadClient) Recv() (*p4_v1.ReadResponse, error) {
+	if c.recvFn == nil {
+		panic("No mock provided for Recv function")
+	}
+	return c.recvFn()
+}
+
+func newTestClient(p4RuntimeClient *fakeP4RuntimeClient, p4Info *p4_config_v1.P4Info) *Client {
+	return &Client{
+		ClientOptions:   defaultClientOptions,
+		P4RuntimeClient: p4RuntimeClient,
+		deviceID:        1,
+		electionID:      p4_v1.Uint128{High: 0, Low: 1},
+		streamSendCh:    make(chan *p4_v1.StreamMessageRequest, 1000),
+		p4Info:          p4Info,
+	}
+}

--- a/pkg/client/counters_test.go
+++ b/pkg/client/counters_test.go
@@ -1,0 +1,88 @@
+package client
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+
+	p4_config_v1 "github.com/p4lang/p4runtime/go/p4/config/v1"
+	p4_v1 "github.com/p4lang/p4runtime/go/p4/v1"
+)
+
+// TestReadCounterEntryWildcard_BadEntity ensures that if the server returns an unexpected entity
+// (in our case a TableEntry instead of a CounterEntry), ReadCounterEntryWildcard will fail with an
+// error instead of blocking indefinitely.
+func TestReadCounterEntryWildcard_BadEntity(t *testing.T) {
+	counterName := "testCounter"
+	counterId := uint32(100)
+	count := 0
+	// we need the number of entities following the "bad" entity to exceed the channel capacity
+	numEntities := counterWildcardReadChSize + 10
+	p4RtReadClient := &fakeP4RuntimeReadClient{
+		recvFn: func() (*p4_v1.ReadResponse, error) {
+			if count > 0 {
+				return nil, io.EOF
+			}
+			count += 1
+			entities := make([]*p4_v1.Entity, 0, numEntities)
+			badEntity := &p4_v1.Entity{
+				Entity: &p4_v1.Entity_TableEntry{},
+			}
+			entities = append(entities, badEntity)
+			data := &p4_v1.CounterData{
+				ByteCount:   1500,
+				PacketCount: 1,
+			}
+			for i := 1; i < numEntities; i++ {
+				entities = append(entities, &p4_v1.Entity{
+					Entity: &p4_v1.Entity_CounterEntry{
+						CounterEntry: &p4_v1.CounterEntry{
+							CounterId: counterId,
+							Index:     &p4_v1.Index{Index: int64(i)},
+							Data:      data,
+						},
+					},
+				})
+			}
+			return &p4_v1.ReadResponse{
+				Entities: entities,
+			}, nil
+		},
+	}
+	p4RtClient := &fakeP4RuntimeClient{
+		readFn: func(ctx context.Context, in *p4_v1.ReadRequest, opts ...grpc.CallOption) (p4_v1.P4Runtime_ReadClient, error) {
+			return p4RtReadClient, nil
+		},
+	}
+	p4Info := &p4_config_v1.P4Info{
+		Counters: []*p4_config_v1.Counter{
+			{
+				Preamble: &p4_config_v1.Preamble{
+					Name: counterName,
+					Id:   counterId,
+				},
+			},
+		},
+	}
+	fakeClient := newTestClient(p4RtClient, p4Info)
+	doneCh := make(chan struct{})
+	var err error
+	go func() {
+		defer close(doneCh)
+		_, err = fakeClient.ReadCounterEntryWildcard(counterName)
+	}()
+	timeout := 1 * time.Second
+	select {
+	case <-doneCh:
+		break
+	case <-time.After(timeout):
+		assert.FailNowf(t, "Timeout", "ReadCounterEntryWildcard should return within %v", timeout)
+	}
+
+	assert.Error(t, err, "ReadCounterEntryWildcard should return an error because response includes bad entity")
+	assert.EqualError(t, err, "server returned an entity which is not a counter entry!")
+}


### PR DESCRIPTION
For ReadCounterEntryWildcard and ReadTableEntryWildcard.
In the (very unlikely) case that the P4Runtime server returns an
unexpected entity, these functions would block indefinitely.
We also add a unit case for this case, which requires the addition of a
"fake" P4Runtime client.