### PR TITLE
Upgrade Go, Actions and golangci-lint in Github workflows

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,12 +11,12 @@ jobs:
   build:
     runs-on: [ubuntu-latest]
     steps:
-    - name: Set up Go 1.15
-      uses: actions/setup-go@v1
+    - name: Set up Go 1.18
+      uses: actions/setup-go@v3
       with:
-        go-version: 1.15
+        go-version: 1.18
     - name: Check-out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Build binaries
       run: |
         make
@@ -27,12 +27,12 @@ jobs:
   tidy:
     runs-on: [ubuntu-latest]
     steps:
-    - name: Set up Go 1.15
-      uses: actions/setup-go@v1
+    - name: Set up Go 1.18
+      uses: actions/setup-go@v3
       with:
-        go-version: 1.15
+        go-version: 1.18
     - name: Check-out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Check tidiness
       run: |
         ./ci/check-tidy.sh
@@ -41,13 +41,18 @@ jobs:
     name: lint
     runs-on: [ubuntu-latest]
     steps:
-    - uses: actions/checkout@v2
+    - name: Set up Go 1.18
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.18
+    - name: Check-out code
+      uses: actions/checkout@v3
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v2
+      uses: golangci/golangci-lint-action@v3
       with:
         # Required: the version of golangci-lint is required and must be specified without patch version:
         # we always use the latest patch version. Keep this version the same with the one in the Makefile!!
-        version: v1.40
+        version: v1.45
 
         # Optional: show only new issues if it's a pull request. The default value is `false`.
         only-new-issues: false

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ check:
 # code linting
 .golangci-bin:
 	@echo "===> Installing Golangci-lint <==="
-	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $@ v1.40.0
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $@ v1.45.2
 
 .PHONY: golangci
 golangci: .golangci-bin


### PR DESCRIPTION
Because we were not providing a specific Go version for the
golangci-lint job, it was defaulting to 1.18 (latest one), which was not
compatible with our version of golangci-lint.