### PR TITLE
Add support for clone sessions

### DIFF
--- a/pkg/client/pre.go
+++ b/pkg/client/pre.go
@@ -6,6 +6,77 @@ import (
 	p4_v1 "github.com/p4lang/p4runtime/go/p4/v1"
 )
 
+type CloneSessionOptions struct {
+	// ClassOfService defines class_of_service that should be set for cloned packets.
+	ClassOfService uint32
+	// PacketLenBytes defines packet size (in bytes) for cloned packets.
+	// Should be set to non-zero value if packets should be truncated.
+	PacketLenBytes int32
+}
+
+var DefaultCloneSessionOptions = CloneSessionOptions{
+	ClassOfService: 0,
+	PacketLenBytes: 0,
+}
+
+func (c *Client) InsertCloneSession(ctx context.Context, id uint32, ports []uint32, options CloneSessionOptions) error {
+	entry := &p4_v1.CloneSessionEntry{
+		SessionId:         id,
+		ClassOfService:    options.ClassOfService,
+		PacketLengthBytes: options.PacketLenBytes,
+	}
+
+	for _, port := range ports {
+		replica := &p4_v1.Replica{
+			EgressPort: port,
+			Instance:   uint32(0),
+		}
+		entry.Replicas = append(entry.Replicas, replica)
+	}
+
+	preEntry := &p4_v1.PacketReplicationEngineEntry{
+		Type: &p4_v1.PacketReplicationEngineEntry_CloneSessionEntry{
+			CloneSessionEntry: entry,
+		},
+	}
+
+	updateType := p4_v1.Update_INSERT
+	update := &p4_v1.Update{
+		Type: updateType,
+		Entity: &p4_v1.Entity{
+			Entity: &p4_v1.Entity_PacketReplicationEngineEntry{
+				PacketReplicationEngineEntry: preEntry,
+			},
+		},
+	}
+
+	return c.WriteUpdate(ctx, update)
+}
+
+func (c *Client) DeleteCloneSession(ctx context.Context, id uint32) error {
+	entry := &p4_v1.CloneSessionEntry{
+		SessionId: id,
+	}
+
+	preEntry := &p4_v1.PacketReplicationEngineEntry{
+		Type: &p4_v1.PacketReplicationEngineEntry_CloneSessionEntry{
+			CloneSessionEntry: entry,
+		},
+	}
+
+	updateType := p4_v1.Update_DELETE
+	update := &p4_v1.Update{
+		Type: updateType,
+		Entity: &p4_v1.Entity{
+			Entity: &p4_v1.Entity_PacketReplicationEngineEntry{
+				PacketReplicationEngineEntry: preEntry,
+			},
+		},
+	}
+
+	return c.WriteUpdate(ctx, update)
+}
+
 func (c *Client) InsertMulticastGroup(ctx context.Context, mgid uint32, ports []uint32) error {
 	entry := &p4_v1.MulticastGroupEntry{
 		MulticastGroupId: mgid,

--- a/pkg/client/pre.go
+++ b/pkg/client/pre.go
@@ -26,10 +26,10 @@ func (c *Client) InsertCloneSession(ctx context.Context, id uint32, ports []uint
 		PacketLengthBytes: options.PacketLenBytes,
 	}
 
-	for _, port := range ports {
+	for idx, port := range ports {
 		replica := &p4_v1.Replica{
 			EgressPort: port,
-			Instance:   uint32(0),
+			Instance:   uint32(idx),
 		}
 		entry.Replicas = append(entry.Replicas, replica)
 	}


### PR DESCRIPTION
This PR adds support for inserting/removing clone sessions. 

`class_of_service` and `packet_len_bytes` are passed as options. A user can leverage `client.DefaultCloneSessionOptions` to use default settings. 